### PR TITLE
add JOB_TYPE to be compatible with kiosk-frontend 0.4.0+

### DIFF
--- a/benchmarking/__main__.py
+++ b/benchmarking/__main__.py
@@ -98,6 +98,7 @@ if __name__ == '__main__':
         'host': settings.HOST,
         'model_name': settings.MODEL_NAME,
         'model_version': settings.MODEL_VERSION,
+        'job_type': settings.JOB_TYPE,
         'update_interval': settings.UPDATE_INTERVAL,
         'start_delay': settings.START_DELAY,
         'refresh_rate': settings.MANAGER_REFRESH_RATE,

--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -50,6 +50,7 @@ class Job(object):
         self.filepath = str(filepath)
         self.model_name = str(model_name)
         self.model_version = str(model_version)
+        self.job_type = str(kwargs.get('job_type', 'segmentation'))
 
         if not self.model_version.isdigit():
             raise ValueError('`model_version` must be a number, got ' +
@@ -202,6 +203,7 @@ class Job(object):
             'preprocessFunction': self.preprocess,
             'postprocessFunction': self.postprocess,
             'imageName': self.filepath,
+            'jobType': self.job_type,
             'uploadedName': os.path.join(self.upload_prefix, self.filepath),
         }
         host = '{}/api/predict'.format(self.host)

--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -59,6 +59,7 @@ class JobManager(object):
         self.host = host
         self.model_name = model_name
         self.model_version = model_version
+        self.job_type = kwargs.get('job_type', 'segmentation')
 
         self.preprocess = kwargs.get('preprocess', '')
         self.postprocess = kwargs.get('postprocess', '')
@@ -105,6 +106,7 @@ class JobManager(object):
                    host=self.host,
                    model_name=self.model_name,
                    model_version=self.model_version,
+                   job_type=self.job_type,
                    postprocess=self.postprocess,
                    upload_prefix=self.upload_prefix,
                    original_name=original_name,

--- a/benchmarking/settings.py
+++ b/benchmarking/settings.py
@@ -57,6 +57,9 @@ GRAFANA_PASSWORD = config('GRAFANA_PASSWORD', default='admin')
 MODEL = config('MODEL', default='HeLaS3watershed:2')
 MODEL_NAME, MODEL_VERSION = MODEL.split(':')
 
+# Job Type
+JOB_TYPE = config('JOB_TYPE', default='segmentation')
+
 # Pre- and Post-Processing functions
 PREPROCESS = config('PREPROCESS', default='')
 POSTPROCESS = config('POSTPROCESS', default='watershed')


### PR DESCRIPTION
Newer versions of the frontend require a `jobType` parameter in the create job POST requests.

This PR adds a default JOB_TYPE to `settings.py`, `job_manager.py` and `job.py` with a default value of `"segmentation"`.