### PR TITLE
Add environment variables for SCALE and LABEL

### DIFF
--- a/benchmarking/__main__.py
+++ b/benchmarking/__main__.py
@@ -99,6 +99,8 @@ if __name__ == '__main__':
         'model_name': settings.MODEL_NAME,
         'model_version': settings.MODEL_VERSION,
         'job_type': settings.JOB_TYPE,
+        'data_scale': settings.SCALE,
+        'data_label': settings.LABEL,
         'update_interval': settings.UPDATE_INTERVAL,
         'start_delay': settings.START_DELAY,
         'refresh_rate': settings.MANAGER_REFRESH_RATE,

--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -199,6 +199,7 @@ class Job(object):
     @defer.inlineCallbacks
     def create(self):
         # Build a deferred request to the create API
+        # See https://tinyurl.com/u3qs9om for expected POST data
         job_data = {
             'modelName': self.model_name,
             'modelVersion': self.model_version,

--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -51,8 +51,22 @@ class Job(object):
         self.model_name = str(model_name)
         self.model_version = str(model_version)
         self.job_type = str(kwargs.get('job_type', 'segmentation'))
-        self.data_scale = str(kwargs.get('data_scale', ''))
-        self.data_label = str(kwargs.get('data_label', ''))
+
+        data_scale = str(kwargs.get('data_scale', ''))
+        if data_scale:
+            try:
+                data_scale = float(data_scale)
+            except ValueError:
+                raise ValueError('data_scale must be a number.')
+        self.data_scale = data_scale
+
+        data_label = str(kwargs.get('data_label', ''))
+        if data_label:
+            try:
+                data_label = int(data_label)
+            except ValueError:
+                raise ValueError('data_label must be an integer.')
+        self.data_label = data_label
 
         if not self.model_version.isdigit():
             raise ValueError('`model_version` must be a number, got ' +

--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -206,8 +206,8 @@ class Job(object):
             'postprocessFunction': self.postprocess,
             'imageName': self.filepath,
             'jobType': self.job_type,
-            'scale': self.data_scale,
-            'label': self.data_label,
+            'dataRescale': self.data_scale,
+            'dataLabel': self.data_label,
             'uploadedName': os.path.join(self.upload_prefix, self.filepath),
         }
         host = '{}/api/predict'.format(self.host)

--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -51,8 +51,8 @@ class Job(object):
         self.model_name = str(model_name)
         self.model_version = str(model_version)
         self.job_type = str(kwargs.get('job_type', 'segmentation'))
-        self.data_scale = str(kwargs.get('data_scale', '1'))
-        self.data_label = str(kwargs.get('data_label', '0'))
+        self.data_scale = str(kwargs.get('data_scale', ''))
+        self.data_label = str(kwargs.get('data_label', ''))
 
         if not self.model_version.isdigit():
             raise ValueError('`model_version` must be a number, got ' +

--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -51,6 +51,8 @@ class Job(object):
         self.model_name = str(model_name)
         self.model_version = str(model_version)
         self.job_type = str(kwargs.get('job_type', 'segmentation'))
+        self.data_scale = str(kwargs.get('data_scale', '1'))
+        self.data_label = str(kwargs.get('data_label', '0'))
 
         if not self.model_version.isdigit():
             raise ValueError('`model_version` must be a number, got ' +
@@ -204,6 +206,8 @@ class Job(object):
             'postprocessFunction': self.postprocess,
             'imageName': self.filepath,
             'jobType': self.job_type,
+            'scale': self.data_scale,
+            'label': self.data_label,
             'uploadedName': os.path.join(self.upload_prefix, self.filepath),
         }
         host = '{}/api/predict'.format(self.host)

--- a/benchmarking/job_test.py
+++ b/benchmarking/job_test.py
@@ -104,12 +104,28 @@ class TestJob(object):
         assert j.is_done
         assert not j.is_summarized  # status=done AND other fields are not None
 
+        # model_version should be an integer
         with pytest.raises(ValueError):
-            # model_version should be an integer
             job.Job(filepath='test.png',
                     host='localhost',
                     model_name='model',
                     model_version='version')
+
+        # data_scale should be a float
+        with pytest.raises(ValueError):
+            job.Job(filepath='test.png',
+                    host='localhost',
+                    model_name='model',
+                    model_version='version',
+                    data_scale='one')
+
+        # data_label should be an int
+        with pytest.raises(ValueError):
+            job.Job(filepath='test.png',
+                    host='localhost',
+                    model_name='model',
+                    model_version='1',
+                    data_label='3.14')
 
     def test__log_http_response(self):
         j = _get_default_job()

--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -60,8 +60,22 @@ class JobManager(object):
         self.model_name = model_name
         self.model_version = model_version
         self.job_type = kwargs.get('job_type', 'segmentation')
-        self.data_scale = str(kwargs.get('data_scale', ''))
-        self.data_label = str(kwargs.get('data_label', ''))
+
+        data_scale = str(kwargs.get('data_scale', ''))
+        if data_scale:
+            try:
+                data_scale = float(data_scale)
+            except ValueError:
+                raise ValueError('data_scale must be a number.')
+        self.data_scale = data_scale
+
+        data_label = str(kwargs.get('data_label', ''))
+        if data_label:
+            try:
+                data_label = int(data_label)
+            except ValueError:
+                raise ValueError('data_label must be an integer.')
+        self.data_label = data_label
 
         self.preprocess = kwargs.get('preprocess', '')
         self.postprocess = kwargs.get('postprocess', '')

--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -60,6 +60,8 @@ class JobManager(object):
         self.model_name = model_name
         self.model_version = model_version
         self.job_type = kwargs.get('job_type', 'segmentation')
+        self.data_scale = str(kwargs.get('data_scale', '1'))
+        self.data_label = str(kwargs.get('data_label', '0'))
 
         self.preprocess = kwargs.get('preprocess', '')
         self.postprocess = kwargs.get('postprocess', '')

--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -123,6 +123,8 @@ class JobManager(object):
                    model_name=self.model_name,
                    model_version=self.model_version,
                    job_type=self.job_type,
+                   data_scale=self.data_scale,
+                   data_label=self.data_label,
                    postprocess=self.postprocess,
                    upload_prefix=self.upload_prefix,
                    original_name=original_name,

--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -60,8 +60,8 @@ class JobManager(object):
         self.model_name = model_name
         self.model_version = model_version
         self.job_type = kwargs.get('job_type', 'segmentation')
-        self.data_scale = str(kwargs.get('data_scale', '1'))
-        self.data_label = str(kwargs.get('data_label', '0'))
+        self.data_scale = str(kwargs.get('data_scale', ''))
+        self.data_label = str(kwargs.get('data_label', ''))
 
         self.preprocess = kwargs.get('preprocess', '')
         self.postprocess = kwargs.get('postprocess', '')

--- a/benchmarking/manager_test.py
+++ b/benchmarking/manager_test.py
@@ -44,6 +44,31 @@ from benchmarking import settings
 
 class TestJobManager(object):
 
+    def test_init(self):
+        mgr = manager.JobManager(
+            host='localhost',
+            model_name='m',
+            model_version='0',
+            data_scale='1',
+            data_label='1')
+
+        # test bad data_scale value
+        with pytest.raises(ValueError):
+            mgr = manager.JobManager(
+                host='localhost',
+                model_name='m',
+                model_version='0',
+                data_scale='one',
+                data_label='1')
+        # test bad data_label value
+        with pytest.raises(ValueError):
+            mgr = manager.JobManager(
+                host='localhost',
+                model_name='m',
+                model_version='0',
+                data_scale='1',
+                data_label='1.3')
+
     def test_make_job(self):
         mgr = manager.JobManager(
             host='localhost',

--- a/benchmarking/manager_test.py
+++ b/benchmarking/manager_test.py
@@ -73,10 +73,15 @@ class TestJobManager(object):
         mgr = manager.JobManager(
             host='localhost',
             model_name='m',
-            model_version='0')
+            model_version='0',
+            data_scale='1',
+            data_label='0')
 
         j1 = mgr.make_job('test.png', original_name=None)
         j2 = mgr.make_job('test.png', original_name='test.png')
+
+        assert j1.data_scale == mgr.data_scale == j2.data_scale
+        assert j1.data_label == mgr.data_label == j2.data_label
 
         assert j1.json() == j2.json()
 

--- a/benchmarking/settings.py
+++ b/benchmarking/settings.py
@@ -59,6 +59,8 @@ MODEL_NAME, MODEL_VERSION = MODEL.split(':')
 
 # Job Type
 JOB_TYPE = config('JOB_TYPE', default='segmentation')
+SCALE = config('SCALE', default='')  # detect scale automatically
+LABEL = config('LABEL', default='')  # detect data type automatically
 
 # Pre- and Post-Processing functions
 PREPROCESS = config('PREPROCESS', default='')

--- a/benchmarking/settings.py
+++ b/benchmarking/settings.py
@@ -59,8 +59,8 @@ MODEL_NAME, MODEL_VERSION = MODEL.split(':')
 
 # Job Type
 JOB_TYPE = config('JOB_TYPE', default='segmentation')
-SCALE = config('SCALE', default='')  # detect scale automatically
-LABEL = config('LABEL', default='')  # detect data type automatically
+SCALE = config('SCALE', default='1')  # detect scale automatically if empty
+LABEL = config('LABEL', default='')   # detect data type automatically if empty
 
 # Pre- and Post-Processing functions
 PREPROCESS = config('PREPROCESS', default='')


### PR DESCRIPTION
Add `SCALE` and `LABEL` so the benchmarking pod can shortcut the scale detection or label detection, if requested.

This is required in order to make benchmarking backwards-compatible.