### PR TITLE
Force finished jobs to summarize()

### DIFF
--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -151,6 +151,9 @@ class JobManager(object):
             if j.failed:
                 j.restart(delay=self.start_delay * failed)
 
+            if j.status == 'done' and not j.is_summarized:
+                j.summarize()
+
         self.logger.info('%s created; %s finished; %s summarized; '
                          '%s; %s jobs total', created, expired, complete,
                          '; '.join('%s %s' % (v, k)

--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -151,6 +151,7 @@ class JobManager(object):
             if j.failed:
                 j.restart(delay=self.start_delay * failed)
 
+            # TODO: patched! "done" jobs can get stranded before summarization
             if j.status == 'done' and not j.is_summarized:
                 j.summarize()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Pillow>=6.2.0
 python-decouple>=3.1,<4
 python-dateutil==2.8.0
 treq==18.6.0
-twisted>=19.7.0
+twisted>=19.7.0,<20.0.0


### PR DESCRIPTION
Some jobs had status `"done"` but did not ever get summarized. This PR makes the manager force jobs with status `"done"` to call `summarize()`.