### PR TITLE
Upgrade twisted to >=20.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache: pip
 
 install:
   - pip install -r requirements.txt
-  - pip install pytest pytest-twisted pytest-cov pytest-pep8 coveralls
+  - pip install -U pytest pytest-twisted pytest-cov pytest-pep8 coveralls
 
 script:
   - pytest --cov=benchmarking --pep8 benchmarking

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache: pip
 
 install:
   - pip install -r requirements.txt
-  - pip install pytest pytest-twisted pytest-cov==2.5.1 pytest-pep8 coveralls
+  - pip install pytest pytest-twisted pytest-cov pytest-pep8 coveralls
 
 script:
   - pytest --cov=benchmarking --pep8 benchmarking

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache: pip
 
 install:
   - pip install -r requirements.txt
-  - pip install -U pytest pytest-twisted pytest-cov pytest-pep8 coveralls
+  - pip install -U pytest pytest-twisted pytest-cov pytest-pep8 coveralls attrs>=19.2.0
 
 script:
   - pytest --cov=benchmarking --pep8 benchmarking

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ Pillow>=6.2.0
 python-decouple>=3.1,<4
 python-dateutil==2.8.0
 treq==18.6.0
-twisted>=19.7.0,<20.0.0
+twisted>=20.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ google-cloud-storage>=1.12.0
 Pillow>=6.2.0
 python-decouple>=3.1,<4
 python-dateutil==2.8.0
-treq==18.6.0
+treq==20.3.0
 twisted>=20.3.0


### PR DESCRIPTION
- Upgrade `twisted` and `treq` to 20.3.0 to resolve CVE-2020-10108.
- Install latest testing dependencies
- Pin `attrs` to >=19.2.0 to incompaitibility error.