### PR TITLE
Add "Connection: close" header to requests.

### DIFF
--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -168,6 +168,7 @@ class Job(object):
 
     def _make_post_request(self, host, data, **kwargs):
         req_kwargs = {
+            'Connection': 'close',
             'headers': kwargs.get('headers', self.headers),
             'pool': kwargs.get('pool', self.pool)
         }

--- a/benchmarking/job.py
+++ b/benchmarking/job.py
@@ -82,7 +82,10 @@ class Job(object):
         self.failed = False  # for error handling
         self.is_expired = False
 
-        self.headers = {'Content-Type': ['application/json']}
+        self.headers = {
+            'Content-Type': ['application/json'],
+            'Connection': 'close',
+        }
 
         # summary data
         self.status = None
@@ -168,7 +171,6 @@ class Job(object):
 
     def _make_post_request(self, host, data, **kwargs):
         req_kwargs = {
-            'Connection': 'close',
             'headers': kwargs.get('headers', self.headers),
             'pool': kwargs.get('pool', self.pool)
         }

--- a/benchmarking/manager.py
+++ b/benchmarking/manager.py
@@ -151,13 +151,13 @@ class JobManager(object):
             if j.failed:
                 j.restart(delay=self.start_delay * failed)
 
-            # TODO: patched! "done" jobs can get stranded before summarization
-            if j.status == 'done' and not j.is_summarized:
-                j.summarize()
-
-            # TODO: patched! sometimes jobs don't get expired?
-            elif j.status == 'done' and j.is_summarized and not j.is_expired:
-                j.expire()
+            # # TODO: patched! "done" jobs can get stranded before summarization
+            # if j.status == 'done' and not j.is_summarized:
+            #     j.summarize()
+            #
+            # # TODO: patched! sometimes jobs don't get expired?
+            # elif j.status == 'done' and j.is_summarized and not j.is_expired:
+            #     j.expire()
 
         self.logger.info('%s created; %s finished; %s summarized; '
                          '%s; %s jobs total', created, expired, complete,


### PR DESCRIPTION
This should resolve a bug where the client's outgoing ports were all filled, making it impossible to send any more requests. (Fixes #43)

This PR also removes the "patches" introduced in later 0.2.x versions. The JobManager would force-summarize and force-expire jobs that it thought were ready for that. However, this had some unintended consequences, including having keys that got expired before they were supposed to be. I believe these patches were also a contributing factor in the ports issue mentioned above.

I've run a few 1M image jobs with this branch with 8 and 1 GPU, and everything seems to be working as expected. 